### PR TITLE
chore(PL-5606): bump Go toolchain to go1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/silphid/jen
 
 go 1.24.0
+toolchain go1.26.3
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.9


### PR DESCRIPTION
Bumps the Go toolchain directive to go1.26.3, resolving Snyk findings for stdlib packages which are fixed in newer Go toolchain versions.