### PR TITLE
fix(PL-4574): include repo path in unstaged changes error message

### DIFF
--- a/cmd/jen/cmd/internal/internal.go
+++ b/cmd/jen/cmd/internal/internal.go
@@ -85,7 +85,7 @@ func maybePull() error {
 
 	logging.Log("Running git pull in %s ...\n", jenHome)
 	if err := shell.ExecuteOutputOnlyErrors(nil, jenHome, "git pull"); err != nil {
-		return fmt.Errorf("pulling latest templates: %w\nuse --skip-pull flag to bypass pulling template git repo", err)
+		return fmt.Errorf("pulling latest templates in %s: %w\nuse --skip-pull flag to bypass pulling template git repo", jenHome, err)
 	}
 
 	if err := os.WriteFile(sentinelFile, []byte{}, 0644); err != nil {


### PR DESCRIPTION
## What
Include the jen templates repo path in the error message when `git pull` fails due to unstaged changes (or any other git pull failure).

**Before:**
```
Error: pulling latest templates: exit status 128
use --skip-pull flag to bypass pulling template git repo
```

**After:**
```
Error: pulling latest templates in /Users/nic/.jen/repo: exit status 128
use --skip-pull flag to bypass pulling template git repo
```

## Why
Without the path, the error is inscrutable — users have no idea which repo has the unstaged changes and where to go to clean it up.

## Test Plan

Manually verified with a local build.

<details>
<summary>Details</summary>

- Built the modified binary with `go build -o /tmp/jen-test ./cmd/jen/`
- Set `JEN_CLONE` to a temp git repo with no upstream, forcing `git pull` to fail
- Confirmed the repo path appears in the error:
  ```
  Error: pulling latest templates in /tmp/test-repo: exit status 1
  use --skip-pull flag to bypass pulling template git repo
  ```
- Change is a single `fmt.Errorf` argument addition; `jenHome` was already in scope on the same line

</details>

## References
- [PL-4574](https://nestoca.atlassian.net/browse/PL-4574)

[PL-4574]: https://nestoca.atlassian.net/browse/PL-4574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ