### PR TITLE
chore(PL-5975): bump Go toolchain to go1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/silphid/jen
 
 go 1.24.0
-toolchain go1.26.3
+
+toolchain go1.26.4
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.9


### PR DESCRIPTION
## Summary
- Bump Go toolchain to 1.26.4 to resolve recently discovered stdlib CVEs published 2026-06-03:
  - [`std/crypto/x509`](https://security.snyk.io/vuln/SNYK-GOLANG-STDCRYPTOX509-17135840) — High
  - [`std/mime`](https://security.snyk.io/vuln/SNYK-GOLANG-STDMIME-17135844) — High
  - [`std/net/textproto`](https://security.snyk.io/vuln/SNYK-GOLANG-STDNETTEXTPROTO-17135843) — Medium

Closes PL-5975

## Test plan
- [ ] `GOTOOLCHAIN=go1.26.4 snyk test --all-projects` returns no vulnerable paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line toolchain bump with no code or dependency changes; low risk aside from verifying CI/builds on the new toolchain.
> 
> **Overview**
> Updates the **`toolchain`** directive in `go.mod` from **go1.26.3** to **go1.26.4** so builds use a patched Go release. The **`go`** language version remains **1.24.0**; only the toolchain used to compile the module changes.
> 
> This is intended to address recently published **stdlib CVEs** (e.g. in `crypto/x509`, `mime`, and `net/textproto`) without altering application source or dependency versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f5f5da0d7ba72e35ab140f8ba1018fb89239e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->