### PR TITLE
fix(PL-5740): upgrade libcap2 to patched version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,8 @@ RUN go build
 
 FROM debian:13.4
 
+# Explicitly install libcap2 to pick up fix for SNYK-DEBIAN13-LIBCAP2-15960217 from trixie-security (PL-5740).
+RUN apt-get update && apt-get install -y --no-install-recommends libcap2 && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/jen /jen
 CMD ["bash"]


### PR DESCRIPTION
## Summary

Explicitly installs `libcap2` in the runtime stage to upgrade from the vulnerable version shipped with `debian:13.4`, addressing SNYK-DEBIAN13-LIBCAP2-15960217

Fixes PL-5740

## Snyk container test results

Scanned with `snyk container test` on the runtime stage image (`FROM debian:13.4`) before and after this change:

| | Before | After |
|---|---|---|
| `libcap2` (SNYK-DEBIAN13-LIBCAP2-15960217) | **High** — `1:2.75-10+b8` | ✅ fixed — `1:2.75-10+deb13u1+b1` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Container-only dependency bump with no application code changes; low operational risk aside from image rebuild/redeploy.
> 
> **Overview**
> The runtime stage of the **Dockerfile** now runs **`apt-get install libcap2`** after **`FROM debian:13.4`**, pulling the patched package from Debian security updates instead of relying on the base image’s bundled **`libcap2`**.
> 
> This targets **SNYK-DEBIAN13-LIBCAP2-15960217** (PL-5740); Snyk container scans reported the fix moving from vulnerable **`1:2.75-10+b8`** to **`1:2.75-10+deb13u1+b1`**. The build stage is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9147f8dae344b8efe32a8db5d7ec1a2fbc671a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->