### PR TITLE
fix(PL-6101): use upstream TriPSs/conventional-changelog-action

### DIFF
--- a/.github/workflows/test-build-publish.yaml
+++ b/.github/workflows/test-build-publish.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Generate changelog and tag release
         id: changelog
-        uses: nestoca/conventional-changelog-action@releases/v5
+        uses: TriPSs/conventional-changelog-action@3c4970b6573374889b897403d2f1278c395ea0df # releases/v5
         with:
           input-file: CHANGELOG.md
           output-file: CHANGELOG.md


### PR DESCRIPTION
## What

Switch from `nestoca/conventional-changelog-action` to `TriPSs/conventional-changelog-action@3c4970b6 # releases/v5` (upstream).

## Why

Maintaining the nestoca fork is unnecessary overhead. Pinning an action to a specific upstream commit SHA gives the same supply-chain guarantee as maintaining a fork — making the fork unnecessary. We're dropping the fork in favour of pinning directly to the upstream release branch.

## References

- [PL-6101](https://nestoca.atlassian.net/browse/PL-6101) — Switch back to TriPSs/conventional-changelog-action from nestoca fork
- [PL-5691](https://nestoca.atlassian.net/browse/PL-5691) — Original Snyk/security ticket
- Slack: https://nestomortgage.slack.com/archives/C02RCBVTJ3G/p1780940095066939

[PL-6101]: https://nestoca.atlassian.net/browse/PL-6101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PL-5691]: https://nestoca.atlassian.net/browse/PL-5691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow dependency swap with a pinned SHA and identical step inputs; no application or auth logic changes.
> 
> **Overview**
> **CI release workflow** — the “Generate changelog and tag release” step in `test-build-publish.yaml` no longer uses `nestoca/conventional-changelog-action@releases/v5`. It now calls **`TriPSs/conventional-changelog-action@3c4970b6573374889b897403d2f1278c395ea0df`** (commented as `releases/v5`).
> 
> All **`with:` inputs are unchanged** (`input-file`, `output-file`, `fallback-version`, skip flags, `git-push: false`), so changelog generation behavior should stay the same; only the action source and commit pin differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc5f6c6730e0456514ab62e501d35668a6e9b36f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->