### PR TITLE
chore(PL-6749): update go language version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/silphid/jen
 
-go 1.24.0
-
-toolchain go1.26.4
+go 1.26.5
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.9


### PR DESCRIPTION
## What

Bump the `go` directive in go.mod to 1.26.5 (and re-run `go mod tidy`).

## Why

Fixes the Snyk `std/os` finding, which requires Go >= 1.25.12 / 1.26.5 / 1.27.0-rc.2.

## References

- :ticket: https://nestoca.atlassian.net/browse/PL-6749